### PR TITLE
Salva histórico no localStorage em itens diferentes para users diferentes

### DIFF
--- a/client/src/actions/salvarHistoricoPesquisa.js
+++ b/client/src/actions/salvarHistoricoPesquisa.js
@@ -6,10 +6,20 @@ const salvarHistoricoPesquisa = ({ artist, album }, userId) => async (
     getState().historicoPesquisa.shift();
   }
 
+  // checar se histórico existe. se não existir, criar histórico
+  localStorage.getItem(`historico${userId}`)
+    ? (getState().historicoPesquisa = JSON.parse(
+        localStorage.getItem(`historico${userId}`)
+      ))
+    : localStorage.setItem(
+        `historico${userId}`,
+        JSON.stringify(getState().historicoPesquisa)
+      );
+
   dispatch({ type: "SAVE_SEARCH_HISTORY", payload: { artist, album, userId } });
 
   localStorage.setItem(
-    "historicoPesquisa",
+    `historico${userId}`,
     JSON.stringify(getState().historicoPesquisa)
   );
 };

--- a/client/src/actions/userActions.js
+++ b/client/src/actions/userActions.js
@@ -44,7 +44,8 @@ export const login = ({ email, password }) => async (dispatch) => {
   }
 };
 
-export const logout = () => (dispatch) => {
+export const logout = () => (dispatch, getState) => {
+  getState().historicoPesquisa = [];
   localStorage.removeItem("userData");
   dispatch({
     type: USER_LOGOUT,

--- a/client/src/components/SearchInput/index.js
+++ b/client/src/components/SearchInput/index.js
@@ -33,16 +33,20 @@ const Index = ({ placeholder, search }) => {
       // certificar de que album está vazio
       buscarPor === "artist" &&
         setSearchTerm((state) => ({ ...state, album: "" }));
-      // salva pesquisa e redireciona para a página do artista
-      dispatch(salvarHistoricoPesquisa(searchTerm, userId));
+      if (userData) {
+        // salva pesquisa e redireciona para a página do artista
+        dispatch(salvarHistoricoPesquisa(searchTerm, userId));
+      }
       history.push(`/artist=${searchTerm.artist}`);
     }
   };
 
   const searchAlbum = () => {
     if (searchTerm.artist !== "" && searchTerm.album !== "") {
-      // salva pesquisa e redireciona para a página do album
-      dispatch(salvarHistoricoPesquisa(searchTerm, userId));
+      if (userData) {
+        // salva pesquisa e redireciona para a página do album
+        dispatch(salvarHistoricoPesquisa(searchTerm, userId));
+      }
       history.push(`/artist=${searchTerm.artist}/album=${searchTerm.album}`);
     }
   };

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -20,9 +20,9 @@ const rootReducer = combineReducers({
   userRegister: userRegisterReducer,
 });
 
-const historicoPesquisaLocalStorage = localStorage.getItem("historicoPesquisa")
-  ? JSON.parse(localStorage.getItem("historicoPesquisa"))
-  : [];
+// const historicoPesquisaLocalStorage = localStorage.getItem("historicoPesquisa")
+//   ? JSON.parse(localStorage.getItem("historicoPesquisa"))
+//   : [];
 
 const userDataLocalStorage = localStorage.getItem("userData")
   ? JSON.parse(localStorage.getItem("userData"))
@@ -30,7 +30,7 @@ const userDataLocalStorage = localStorage.getItem("userData")
 
 const initialState = {
   buscarPor: "artist",
-  historicoPesquisa: historicoPesquisaLocalStorage,
+  historicoPesquisa: [],
   artistData: {},
   albumData: {},
   topArtists: [],


### PR DESCRIPTION
Cada usuário cria um item no localStorage com o userID. Assim, as pesquisas são salvas por usuário específico e na página de pesquisa o usuário só consegue ver as pesquisas que ele realizou.